### PR TITLE
Declare Monolog version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/dotenv": "^5.4 || ^6.0 || ^7.0",
         "symfony/monolog-bundle": "^3.0",
         "sentry/sentry-symfony": "^4.0",
-        "symfony/messenger": "^5.4 || ^6.0 || ^7.0"
+        "symfony/messenger": "^5.4 || ^6.0 || ^7.0",
+        "monolog/monolog": "^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.3",


### PR DESCRIPTION
Else it is possible to have Monolog v2.*, and thus to have conflicts